### PR TITLE
Add option for selection of Route53 zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,13 @@ QuickStart
         pip install -r requirements.txt
 
 3. Export environment variables
-
-        export AWS_ACCESS_KEY_ID="<Insert your AWS Access Key>"
-        export AWS_SECRET_ACCESS_KEY="<Insert your AWS Secret Key>"
-        export AWS_CONNECTION_REGION="us-east-1"
-        _optional_
-        export ROUTE53_ZONE="<Insert zone name>"
-
-If ROUTE53_ZONE is not defined, base domain (TLD + 1) is used.
+   ```
+   export AWS_ACCESS_KEY_ID="<Insert your AWS Access Key>"
+   export AWS_SECRET_ACCESS_KEY="<Insert your AWS Secret Key>"
+   export AWS_CONNECTION_REGION="us-east-1"
+   (optional) export ROUTE53_ZONE="<Insert zone name>"
+   ```
+   If ROUTE53_ZONE is not defined, base domain (TLD + 1) is used, e.g. `example.com`. 
 
 4. Run the script
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ QuickStart
         export AWS_ACCESS_KEY_ID="<Insert your AWS Access Key>"
         export AWS_SECRET_ACCESS_KEY="<Insert your AWS Secret Key>"
         export AWS_CONNECTION_REGION="us-east-1"
+        _optional_
+        export ROUTE53_ZONE="<Insert zone name>"
+
+If ROUTE53_ZONE is not defined, base domain (TLD + 1) is used.
 
 4. Run the script
 

--- a/r53dyndns.py
+++ b/r53dyndns.py
@@ -44,7 +44,10 @@ if len(ip_list) < 1:
     sys.exit(-1)
 current_ip = ip_list[0]
 record_to_update = options.record_to_update
-zone_to_update = '.'.join(record_to_update.split('.')[-2:])
+
+zone_to_update = os.getenv("ROUTE53_ZONE")
+if zone_to_update == None:
+  zone_to_update = '.'.join(record_to_update.split('.')[-2:])
 
 try:
     socket.inet_aton(current_ip)


### PR DESCRIPTION
Previously, the Route53 zone was automatically chosen to be the tld +1 (e.g. for a domain of one.two.example.com, the zone would be example.com).

This doesn't play nicely if you have subdomains whose zones also reside in Route53. (e.g. two.example.com as a delegate zone of example.com, with an A record of one.two.example.com). 

In this PR I have added support for a new environment variable, ROUTE53_ZONE, which if defined specifies the zone to which the update shall occur. If no zone is specified, the python script defaults to using the tld+1 format so as not to break compat. 